### PR TITLE
support togglable URLs with varying delays

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 2,
 	"name": "URL Throttler",
 	"description": "An extension that lets you delay the response from specific URLs",
-	"version": "1.2.0",
+	"version": "2.0.0",
     "icons": {
 		"16": "icon16.png",
 		"48": "icon48.png",

--- a/popup.html
+++ b/popup.html
@@ -102,11 +102,16 @@
       </div>
     </div>
     <div class="field">
-      <button v-on:click="addUrlInput">Add</button>
+      <button v-on:click="addUrlInput">Add URL</button>
+    </div>
+    <hr />
+    <div class="field">
+      <button v-on:click="copyCurrentConfig">Copy Current Config</button>
+      <button v-on:click="applyConfig">Apply New Config</button>
     </div>
     <div class="field">
       <em style="color: rgba(53,142,8,.9);">
-        <span id="lastChangeTime"></span>
+        <span id="messageDisplay"></span>
       </em>
     </div>
   </div>

--- a/popup.html
+++ b/popup.html
@@ -11,7 +11,7 @@
       font-family: sans-serif;
       font-size: 14px;
       padding: 10px;
-      width: 400px;
+      width: 500px;
     }
 
     .field {
@@ -50,6 +50,14 @@
       border: 1px solid #d4d4d4;
     }
 
+    input.delayInput {
+      width: 100px;
+    }
+
+    input[type="checkbox"] {
+      width: 40px;
+    }
+
     button {
       background-color: transparent;
       border: 1px solid #8c8c8c;
@@ -71,7 +79,7 @@
     </div>
     <div class="field">
       <div class="label">Delay (ms):</div>
-      <input class="input" type="number" v-model="delay" />
+      <input class="input" type="number" v-model="defaultDelay" />
     </div>
     <div class="field">
       <div class="label">URLs:</div>
@@ -79,18 +87,27 @@
         URLs must use the <a href="https://developer.chrome.com/docs/extensions/mv2/match_patterns/" target="_blank">Match pattern</a> syntax.
         <br />
         Examples:
-        <br/>
+        <br />
         <code>http://127.0.0.1/*</code>
         <br />
-        <code>*://foobar.com/foo.html</code>
+        <code>*://*/api/foo</code>
+        <br />
+        If no delay is specified below, delay will default to the value specified above.
       </div>
       <div v-for="(url, index) in urls" class="url-item"  v-bind:class="{ error: url.error }">
+        <input type="checkbox" v-model="url.checked" v-bind:id="url.id">
+        <input class="input delayInput" v-model.trim="url.delay" placeholder="Delay (in ms)" />
         <input class="input" v-model.trim="url.url" />
         <button v-on:click="removeUrlInput(index)">Remove</button>
       </div>
     </div>
     <div class="field">
       <button v-on:click="addUrlInput">Add</button>
+    </div>
+    <div class="field">
+      <em style="color: rgba(53,142,8,.9);">
+        <span id="lastChangeTime"></span>
+      </em>
     </div>
   </div>
 </body>

--- a/popup.js
+++ b/popup.js
@@ -28,12 +28,14 @@ chrome.storage.local.get(['requestThrottler'], (result) => {
     methods: {
       applyConfig: function() {
         let newConfig = prompt('Please input new config (it should appear in JSON format as in example below), or leave as {} to reset.\n\n{"defaultDelay":"5000","enabled":true,"urls":[{"checked":true,"error":false,"url":"*://*/api/foo"},{"checked":true,"delay":"2000","error":false,"url":"https://joecoyle.net/api/bar"}]}\n', "{}");
-        try {
-          chrome.storage.local.set({'requestThrottler': JSON.parse(newConfig)}, function() {
-            location.reload();
-          });
-        } catch {
-          alert("Error applying config. Is your JSON formatting correct?");
+        if(newConfig) {
+          try {
+            chrome.storage.local.set({'requestThrottler': JSON.parse(newConfig)}, function() {
+              location.reload();
+            });
+          } catch {
+            alert("Error applying config. Is your JSON formatting correct?");
+          }
         }
       },
       copyCurrentConfig: function() {


### PR DESCRIPTION
### Summary
Togglable URLs with different delay amounts may now be specified. I have found this tool to be extremely helpful in race condition testing, and I believe many users could benefit from this added functionality. 
![image](https://user-images.githubusercontent.com/5075161/179831491-34700993-9015-4ca5-9e00-81c0afee18a6.png)

**Notable Changes**
* background.js
  * New method of matching wildcard URLs implemented (source: https://stackoverflow.com/a/3117248/2969615)
* popup.html
  * _Changed saved @ [timestamp]_ indicator at bottom to make user aware of potential (albeit rare) missed change saves

**Outstanding Issues**
* Delay amounts should be adjusted relative to each other, as in the following example:

>           If I provided the following values:
>           Call A: 5000ms
>           Call B: 2500ms
>           Call C: 10000ms
> 
>           It will actually execute in this order with adjusted amounts:
>           Call B with a delay of 2500ms
>           Call A with a delay of 2500ms
>           Call C with a delay of 5000ms
>  This would work better because currently the delays are held up on the thread so these 3 calls would end up taking 17500ms because the counter won't start ticking on the other calls until the current call is done delaying
> 
>           Considerations:
>             - This might behave strangely if a particular call is matched multiple times
> 
* Manifest will need to be updated to v3 in time for deprecation in 2023